### PR TITLE
Correct grub config location used in build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -249,7 +249,7 @@ else:
 	print("** Creating new system image...")
 	check_result_code(subprocess.run(["dd", "if=/dev/zero", "of=build/disk.img", "bs=1048576", "count=128"]))
 	mount_system_image(True, mountpoint_folder)
-check_result_code(subprocess.run(["cp", "-f", "config/grub.cfg", mountpoint_folder+"/boot/grub2"]))
+check_result_code(subprocess.run(["cp", "-f", "config/grub.cfg", mountpoint_folder+"/boot/grub/grub.cfg"]))
 check_result_code(subprocess.run(["cp", "-f", "build/kernel.elf", mountpoint_folder+"/boot/kernel.elf"]))
 print("** Unmounting system image...")
 unmount_system_image(mountpoint_folder)


### PR DESCRIPTION
It used `/boot/grub2` before. This meant it wouldn't be read.
By moving it to `/boot/grub/grub.cfg`, it is correctly read by GRUB.